### PR TITLE
Extended the languages list to include a column with the language name and a column with the native name.

### DIFF
--- a/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/src/main/java/gherkin/GherkinDialectProvider.java
@@ -16,6 +16,7 @@ import static java.util.Collections.unmodifiableList;
 public class GherkinDialectProvider implements IGherkinDialectProvider {
     private static Map<String, Map<String, List<String>>> DIALECTS;
     private final String default_dialect_name;
+    final int separation = 5;
 
     static {
         Gson gson = new Gson();
@@ -53,6 +54,63 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     public List<String> getLanguages() {
         List<String> languages = new ArrayList<String>(DIALECTS.keySet());
         sort(languages);
-        return unmodifiableList(languages);
+
+        int maxKeyLength = getMaxKeyLength();
+        int maxNameLength = getMaxNameLength();
+
+        List<String> languagesWithExplanation = new ArrayList<String>();
+        for (String key : languages) {
+            Map<String, List<String>> values = DIALECTS.get(key);
+
+            String name = (String) (Object) values.get("name");
+            String nativeName = (String) (Object) values.get("native");
+
+            String languageWithExplanation = formatLanguage(key, maxKeyLength, name, maxNameLength, nativeName);
+            languagesWithExplanation.add(languageWithExplanation);
+        }
+
+        return unmodifiableList(languagesWithExplanation);
     }
+
+    int getMaxKeyLength() {
+        int max = 0;
+        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+
+        for (String key : languages) {
+            if (max < key.length()) {
+                max = key.length();
+            }
+        }
+
+        return max;
+    }
+
+    int getMaxNameLength() {
+        int max = 0;
+        List<String> languages = new ArrayList<String>(DIALECTS.keySet());
+
+        for (String key : languages) {
+            Map<String, List<String>> values = DIALECTS.get(key);
+            String name = (String) (Object) values.get("name");
+
+            if (max < name.length()) {
+                max = name.length();
+            }
+        }
+
+        return max;
+    }
+
+    private String formatLanguage(String key, int maxKeyLength, String name, int maxNameLength, String nativeName) {
+        int keyNameSeparation = maxKeyLength + separation;
+        String result = String.format("%1$-" + keyNameSeparation + "s", key);
+        result += name;
+
+        int nameNativeSeparation = keyNameSeparation + maxNameLength + separation;
+        result = String.format("%1$-" + nameNativeSeparation + "s", result);
+        result += nativeName;
+
+        return result;
+    }
+
 }

--- a/src/test/java/gherkin/GherkinDialectProviderTest.java
+++ b/src/test/java/gherkin/GherkinDialectProviderTest.java
@@ -2,13 +2,37 @@ package gherkin;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static gherkin.SymbolCounter.countSymbols;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class GherkinDialectProviderTest {
     @Test
     public void providesEmojiDialect() {
         GherkinDialect em = new GherkinDialectProvider().getDialect("em", null);
         assertEquals(1, countSymbols(em.getScenarioKeywords().get(0)));
+    }
+
+    @Test
+    public void should_include_swedish_in_languages() {
+        GherkinDialectProvider gherkinDialectProvider = new GherkinDialectProvider();
+        List<String> actual = gherkinDialectProvider.getLanguages();
+
+        String expected = getExpected(gherkinDialectProvider);
+
+        assertTrue("Swedish with explanation should be available", actual.contains(expected));
+    }
+
+    private String getExpected(GherkinDialectProvider gherkinDialectProvider) {
+        int keyName = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxKeyLength() - "sv".length();
+        int nameNative = gherkinDialectProvider.separation + gherkinDialectProvider.getMaxNameLength() - "Swedish".length();
+
+        return "sv" + rightPad(keyName) + "Swedish" + rightPad(nameNative) + "Svenska";
+    }
+
+    private String rightPad(int n) {
+        return String.format("%1$-" + n + "s", "");
     }
 }


### PR DESCRIPTION
The list of languages looked like this:

```
af
am
ar
ast
az
bg
…
```

There are 73 languages supported. It isn't easy to know which language is which.

I extended the list to look like this:

```
af            Afrikaans               Afrikaans
am            Armenian                հայերեն
ar            Arabic                  العربية
ast           Asturian                asturianu
az            Azerbaijani             Azərbaycanca
bg            Bulgarian               български
…
```

This will make it easier to understand what language a language code is supporting.